### PR TITLE
Add '--no-check-certificate' to wget

### DIFF
--- a/fetch_packages.py
+++ b/fetch_packages.py
@@ -69,7 +69,7 @@ def ProcessPackage(pkg):
     filename = getFilename(pkg, url)
     ccfile = _PACKAGE_CACHE + '/' + filename
     if not os.path.isfile(ccfile):
-        subprocess.call(['wget', '-O', ccfile, url])
+        subprocess.call(['wget', '--no-check-certificate', '-O', ccfile, url])
 
     #
     # Determine the name of the directory created by the package.


### PR DESCRIPTION
wget calls to pypi fail because it uses a wildcard cert that is not recognized by the default wget. This corrects that and allows the resource to be downloaded.
