### PR TITLE
xen: Fix build break

### DIFF
--- a/fetch_packages.py
+++ b/fetch_packages.py
@@ -178,10 +178,13 @@ def ProcessPackage(pkg):
             if os.path.exists(_TMP_NODE_MODULES + '/' + pkg['name']):
                 cmd = npmCmd
             else:
-                p = subprocess.Popen(cmd, cwd = cd)
-                p.wait()
-                cmd = npmCmd
-
+		try:
+                   p = subprocess.Popen(cmd, cwd = cd)
+                   p.wait()
+                   cmd = npmCmd
+		except OSError:
+		   print ' '.join(cmd) + ' could not be executed, bailing out!'
+		   return
         p = subprocess.Popen(cmd, cwd = cd)
         p.wait()
 


### PR DESCRIPTION
python fetch_packages.py breaks in xen builder as xen doesn't have npm tool. This is not even
required in xen builder. Hence adding fix to catch OSError (thrown if it can't find npm) and
bailout gracefully.

Signed-off-by: Anirban Chakraborty abchak@juniper.net
