### PR TITLE
Patch to change SSL protocol to  TLSv1 and removed RC4 cipher reference

### DIFF
--- a/ifmap-python-patch1.diff
+++ b/ifmap-python-patch1.diff
@@ -55,10 +55,8 @@ index c0f748c..103caa6 100644
  	__namespaces = None
 +	__ssl_options = {
 +		'cert_reqs'   : gevent.ssl.CERT_NONE,
-+		'ssl_version' : PROTOCOL_SSLv23,
++		'ssl_version' : PROTOCOL_TLSv1,
 +	}
-+	if sys.version_info >= (2,7):
-+		__ssl_options['ciphers'] = "RC4-SHA"
  
  	__envelope ="""<?xml version="1.0" encoding="UTF-8"?>
  <env:Envelope xmlns:env="http://www.w3.org/2003/05/soap-envelope" %(ns)s>


### PR DESCRIPTION
A java update on 30th July 2015 patched a security improvement, this update modifies OpenJDK behavior to disable RC4 TLS/SSL cipher suites by default. Hence connection between Contrail-Api and IFmap fails. This also impacts the connection between Contrail-Control and IF-map server.

Ref Link http://www.ubuntu.com/usn/usn-2696-1/



