### PR TITLE
googlecode packages are now in github.com:Juniper/contrail-third-party-cache

### DIFF
--- a/packages.xml
+++ b/packages.xml
@@ -79,7 +79,7 @@
   </package>
   <package>
     <name>Google C++ Testing Framework 1.6.0</name>
-    <url>https://github.com/google/googletest/archive/release-1.6.0.zip</url>
+    <url>https://github.com/Juniper/contrail-third-party-cache/blob/master/googlecode/googletest-release-1.6.0.zip</url>
     <rename>gtest-1.6.0</rename>
     <patches>
       <patch strip="2">gtest-1.6.0_patch1.diff</patch>
@@ -105,7 +105,7 @@
   </package>
   <package>
     <name>Google C++ Mocking Framework 1.6.0</name>
-    <url>https://github.com/google/googlemock/archive/release-1.6.0.zip</url>
+    <url>https://github.com/Juniper/contrail-third-party-cache/blob/master/googlecode/googlemock-release-1.6.0.zip</url>
     <format>zip</format>
     <rename>gmock-1.6.0</rename>
     <md5>b51cc3e69a8ef16ac54cee9889b79646</md5>
@@ -128,7 +128,7 @@
   </package>
   <package>
     <name>Google perftools</name>
-    <url>https://github.com/gperftools/gperftools/releases/download/gperftools-2.1/gperftools-2.1.tar.gz</url>
+    <url>https://github.com/Juniper/contrail-third-party-cache/blob/master/googlecode/gperftools-2.1.tar.gz</url>
     <format>tgz</format>
     <md5>5e5a981caf9baa9b4afe90a82dcf9882</md5>
     <platform>
@@ -314,7 +314,7 @@
   </package>
   <package>
     <name>JSON parser/generator for C++</name>
-    <url>https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/rapidjson/rapidjson-0.11.zip</url>
+    <url>https://github.com/Juniper/contrail-third-party-cache/blob/master/googlecode/rapidjson-0.11.zip</url>
     <format>zip</format>
     <md5>96a4b1b57ece8bc6a807ceb14ccaaf94</md5>
     <patches>


### PR DESCRIPTION
bug 
https://bugs.launchpad.net/opencontrail/+bug/1617479